### PR TITLE
Fix incorrect settings import in sidebar component

### DIFF
--- a/components/sidebar.py
+++ b/components/sidebar.py
@@ -50,7 +50,7 @@ Componente pentru filtrele comune în aplicația Brenado For House
 
 import streamlit as st
 import pandas as pd
-from src.config.settings import FILTER_DEFAULTS
+from config.settings import FILTER_DEFAULTS
 
 def render_multiselect_filter(label, options, key, default=None):
     """


### PR DESCRIPTION
## Summary
- fix sidebar utilities import to use correct settings package
- ensure components module compiles and imports without error

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'PY'
import components.sidebar as sidebar
print('sidebar imported successfully after commit')
PY`


------
https://chatgpt.com/codex/tasks/task_e_689e4ddcfc98832a88d2081ac401b3dd